### PR TITLE
iromlab.py - added missing .config

### DIFF
--- a/iromlab/iromlab.py
+++ b/iromlab/iromlab.py
@@ -536,7 +536,7 @@ class carrierEntry(tk.Frame):
             self.catid_entry.delete(0, tk.END)
             self.catid_entry.focus_set()
         else:
-            self.title_entry(state='normal')
+            self.title_entry.config(state='normal')
             self.usepreviousTitle_button.config(state='normal')
             self.title_entry.delete(0, tk.END)
             self.title_entry.focus_set()


### PR DESCRIPTION
This is the last piece of the puzzle I think. I tested your recent commit and saw:
```
Traceback (most recent call last):
  File "C:\Users\kieran.oleary\Downloads\iromsgl-main\iromlab-launch.py", line 8, in <module>
    main()
  File "C:\Users\kieran.oleary\Downloads\iromsgl-main\iromlab\iromlab.py", line 845, in main
    myCarrierEntry.reset_carrier()
  File "C:\Users\kieran.oleary\Downloads\iromsgl-main\iromlab\iromlab.py", line 539, in reset_carrier
    self.title_entry(state='normal')
TypeError: 'Entry' object is not callable
```

and this fixed it. I got this report at the end which I think means success?

```
2022-06-16 00:25:23,739 - INFO - batchFolder set to C:\kb-6d72be21-ed02-11ec-a970-909c4aba942c
2022-06-16 00:25:32,689 - INFO - ### Job identifier: 739ae70c-ed02-11ec-aea7-909c4aba942c
2022-06-16 00:25:32,689 - INFO - PPN: 
2022-06-16 00:25:32,689 - INFO - Title: asdasd5
2022-06-16 00:25:32,689 - INFO - Volume number: 1
2022-06-16 00:25:32,689 - INFO - disc directory: C:\kb-6d72be21-ed02-11ec-a970-909c4aba942c\739ae70c-ed02-11ec-aea7-909c4aba942c
2022-06-16 00:25:32,689 - INFO - *** Running cd-info ***
2022-06-16 00:25:32,742 - INFO - cd-info command: C:\Users\kieran.oleary\Downloads\iromsgl-main\iromlab\tools\libcdio\win64\cd-info.exe -C E: --no-header --no-device-info --no-disc-mode --no-cddb --dvd
2022-06-16 00:25:32,742 - INFO - cd-info-status: 0
2022-06-16 00:25:32,742 - INFO - cdExtra: False
2022-06-16 00:25:32,742 - INFO - containsAudio: False
2022-06-16 00:25:32,742 - INFO - containsData: True
2022-06-16 00:25:32,742 - INFO - mixedMode: False
2022-06-16 00:25:32,742 - INFO - cdInteractive: False
2022-06-16 00:25:32,742 - INFO - multiSession: False
2022-06-16 00:25:32,742 - INFO - *** Extracting data session to ISO ***
2022-06-16 00:25:49,954 - INFO - isobuster command: C:\Program Files (x86)\Smart Projects\IsoBuster\IsoBuster.exe /d:E: /ei:C:\kb-6d72be21-ed02-11ec-a970-909c4aba942c\739ae70c-ed02-11ec-aea7-909c4aba942c\disc.iso /et:u /ep:oea /ep:npc /c /m /nosplash /s:1 /l:C:\kb-6d72be21-ed02-11ec-a970-909c4aba942c\739ae70c-ed02-11ec-aea7-909c4aba942c\isobuster.log /tree:all:C:\kb-6d72be21-ed02-11ec-a970-909c4aba942c\739ae70c-ed02-11ec-aea7-909c4aba942c\isobuster-report.xml?{'DFXML (IsoBuster 4.2 version)'}{%UTF8}{%DFXML}{%GMT}{%FOLDERS}{%STREAMS}<%XMLHEADER><%BR><dfxml xmlns='http://www.forensicswiki.org/wiki/Category:Digital_Forensics_XML'<%BR> xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'<%BR> xmlns:dc='http://purl.org/dc/elements/1.1/'<%BR> xmlns:hfs='http://www.forensicswiki.org/wiki/HFS' version='1.0'><%BR><%BR> <metadata><%BR> <dc:type><%DEVICETYPE></dc:type><%BR> </metadata><%BR><%BR> <creator><%BR> <program><%APP></program><%BR> <version><%VERSION></version><%BR> <execution_environment><%BR> <start_time><%SYSTIMEDATE></start_time><!--GMT--><%BR> <os_version><%OS></os_version><%BR> <username><%USER></username><%BR> </execution_environment><%BR> </creator><%BR><%BR> <source><%BR> <device_model><%DEVICE></device_model><%BR> <image_filename><%DEVICEPATH></image_filename><%BR> <image_size><%DEVICEFILESIZE></image_size><%BR> <sectorsize><%DEVICEBLOCKSIZE></sectorsize><%BR> <devicesectors coding='base10'><%DEVICEBLOCKS></devicesectors><%BR> </source><%BR><%BR> <volume><%BR> <partition_offset><%PARTITIONLBABYTESOFFSET></partition_offset><%BR> <ftype_str><%TYPE></ftype_str>{%HEADER}{%FOLDER}<%BR> <fileobject><%BR> <filename><%RELPATH></filename><%BR> <name_type>d</name_type><%BR> <filesize><%BYTES></filesize><%BR> <alloc>1</alloc><%BR> <inode><%UID></inode><%BR> <mtime><%TIMEDATE></mtime><!--GMT--><%BR> <byte_runs><%EXTENTLOOP> </byte_runs><%BR> </fileobject>{%FILE}<%BR> <fileobject><%BR> <filename><%RELPATH></filename><%BR> <name_type>r</name_type><%BR> <filesize><%BYTES></filesize><%BR> <alloc>1</alloc><%BR> <inode><%UID></inode><%BR> <mtime><%TIMEDATE></mtime><!--GMT--><%BR> <hfs:HFStype_creator><%TYPE>/<%CREATOR></hfs:HFStype_creator><!--Only relevant if MAC File System--><%BR> <byte_runs><%EXTENTLOOP> </byte_runs><%BR> </fileobject>{%STREAM}<%BR> <fileobject><!--Stream or Resource Fork--><%BR> <filename><%RELPATH></filename><%BR> <name_type>-</name_type><%BR> <filesize><%BYTES></filesize><%BR> <alloc>1</alloc><%BR> <inode><%UID></inode><%BR> <mtime><%TIMEDATE></mtime><!--GMT--><%BR> <byte_runs><%EXTENTLOOP> </byte_runs><%BR> </fileobject>{%EXTENT} <byte_run img_offset='<%LBABYTEOFFSET>' len='<%BYTES>' />{%FOOTER} </volume><%BR><%BR> <runstats><%BR> <stop_time><%SYSTIMEDATE></stop_time><!--GMT--><%BR> <clock_seconds><%SYSTIMELAPSEDSEC></clock_seconds><%BR> </runstats><%BR><%BR></dfxml><%BR><!-- For more information: https://www.isobuster.com/reports -->
2022-06-16 00:25:49,954 - INFO - isobuster-status: 0
2022-06-16 00:25:49,955 - INFO - isobuster-log: 0
2022-06-16 00:25:49,955 - INFO - volumeIdentifier: CDROM
2022-06-16 00:25:49,955 - INFO - isolyzerSuccess: True
2022-06-16 00:25:49,955 - INFO - imageTruncated: False
2022-06-16 00:25:49,956 - INFO - *** Computing checksums ***
2022-06-16 00:25:50,153 - INFO - *** Finished processing disc ***
```